### PR TITLE
Lifting state up of display component

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -207,7 +207,6 @@ export default class App extends React.Component {
           onFieldMappingChange={this.onFieldMappingChange}
           width={WIDTH_OF_COLUMN}
           empty={EMPTY}
-          table={TABLE}
           text={TEXT}
           availableFieldsSettings={this.state.availableFieldsSettings}
           mapInput={this.mapInput}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -98,33 +98,27 @@ export default class App extends React.Component {
   }
 
   onFieldMappingChange(index, selectIndex) {
-    let csvFieldValue
-    if (selectIndex === 0) {
-      csvFieldValue = this.state.availableFieldsState[index].fieldValue
-    } else {
-      csvFieldValue = selectIndex
-    }
+    const csvFieldValue = (selectIndex === 0)
+      ? this.state.availableFieldsState[index].fieldValue
+      : selectIndex
     const mappingSource = (selectIndex === 0) ? TEXT : TABLE
     const pdfFieldName = this.state.pdfFields[index].fieldName
     this.setState(
       prevState => {
-        let newFieldMappingsEntry
-        if (csvFieldValue === "") {
-          newFieldMappingsEntry = undefined
-        } else {
-          newFieldMappingsEntry = {
-            fieldName: pdfFieldName,
-            mapping: mappingSource === TABLE
-              ? {
-                  source: TABLE,
-                  columnNumber: csvFieldValue,
-                }
-              : {
-                  source: TEXT,
-                  text: csvFieldValue,
-                }
-          }
-        }
+        const newFieldMappingsEntry = (csvFieldValue === "")
+          ? undefined
+          : {
+              fieldName: pdfFieldName,
+              mapping: mappingSource === TABLE
+                ? {
+                    source: TABLE,
+                    columnNumber: csvFieldValue,
+                  }
+                : {
+                    source: TEXT,
+                    text: csvFieldValue,
+                  }
+            }
         const fieldMappings = [...prevState.fieldMappings]
         fieldMappings[index] = newFieldMappingsEntry
         return {fieldMappings}
@@ -132,10 +126,17 @@ export default class App extends React.Component {
   }
 
   setAvailableFieldsState(index, setting) {
-    this.setState(prevState =>
-      ({availableFieldsState: prevState.availableFieldsState.map((element, i) =>
-        (i === index) ? Object.assign({}, element, setting) : element
-      )}))
+    this.setState(
+      prevState =>
+        ({
+          availableFieldsState: prevState.availableFieldsState.map(
+            (element, i) =>
+              (i === index)
+                ? Object.assign({}, element, setting)
+                : element
+          )
+        })
+    )
   }
 
   render() {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -26,19 +26,19 @@ export default class App extends React.Component {
       availableFieldsState: [],
     }
 
+    const mapPdfFields = element => ({
+      canEdit: true,
+      isEditingCustomValue: false,
+      fieldValue: element.fieldValue,
+      selectIndex: 0
+    })
+
     ipcRenderer.on('pdf-fields-available', (event, pdfTemplatePath, fields) => {
       this.setState(prevState => ({
         pdfFields: fields,
         pdfTemplatePath,
         fieldMappings: [],
-        availableFieldsState: prevState.pdfFields.map(
-            element => ({
-              canEdit: true,
-              isEditingCustomValue: false,
-              fieldValue: element.fieldValue,
-              selectIndex: 0
-            })
-          )
+        availableFieldsState: prevState.pdfFields.map(mapPdfFields)
       }))
     })
 
@@ -46,14 +46,7 @@ export default class App extends React.Component {
       this.setState(prevState => ({
         csvFields: fields,
         fieldMappings: [],
-        availableFieldsState: prevState.pdfFields.map(
-          element => ({
-            canEdit: true,
-            isEditingCustomValue: false,
-            fieldValue: element.fieldValue,
-            selectIndex: 0
-          })
-        ),
+        availableFieldsState: prevState.pdfFields.map(mapPdfFields)
       }))
     })
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -127,8 +127,7 @@ export default class App extends React.Component {
               }
         }
         return partialState
-      }
-    , console.log(this.state))
+      })
   }
 
   render() {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -65,7 +65,8 @@ export default class App extends React.Component {
         element => ({
           canEdit: true,
           isEditingCustomValue: false,
-          fieldValue: element.fieldValue
+          fieldValue: element.fieldValue,
+          selectIndex: 0
         })
       ),
     }
@@ -147,8 +148,8 @@ export default class App extends React.Component {
       )}))
   }
 
-  mapInput(pdfField, csvField, source, canEdit, index) {
-    this.copyAvailableFieldsSettings(index, {canEdit})
+  mapInput(pdfField, csvField, source, canEdit, index, selectIndex) {
+    this.copyAvailableFieldsSettings(index, {canEdit, selectIndex})
     this.onFieldMappingChange(
       csvField,
       pdfField,

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -96,26 +96,26 @@ export default class App extends React.Component {
         this.state.fieldMappings.filter(element => typeof element !== 'undefined'))
   }
 
-  setFieldMapping(index, flags) {
+  setFieldMapping(index, updates) {
     this.setState(
       prevState => {
         let partialState = {}
         partialState.availableFieldsState = prevState.availableFieldsState.map(
           (element, i) =>
             (i === index)
-              ? Object.assign({}, element, flags.state)
+              ? Object.assign({}, element, updates.state)
               : element
         )
-        if (flags.shouldSetFieldMapping) {
-          const csvFieldValue = (flags.selectedIndex === 0)
+        if (typeof updates.selectedIndex !== 'undefined') {
+          const csvFieldValue = (updates.selectedIndex === 0)
             ? prevState.availableFieldsState[index].fieldValue
-            : flags.selectedIndex
+            : updates.selectedIndex
           partialState.fieldMappings = [...prevState.fieldMappings]
           partialState.fieldMappings[index] = (csvFieldValue === "")
             ? undefined
             : {
                 fieldName: prevState.pdfFields[index].fieldName,
-                mapping: flags.selectedIndex === 0
+                mapping: updates.selectedIndex === 0
                   ? {
                       source: TEXT,
                       text: csvFieldValue,

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -148,12 +148,13 @@ export default class App extends React.Component {
       )}))
   }
 
-  mapInput(pdfField, csvField, source, canEdit, index, selectIndex) {
-    this.copyAvailableFieldsSettings(index, {canEdit, selectIndex})
+  mapInput(pdfField, csvField, index, selectIndex) {
+    this.copyAvailableFieldsSettings(index, {selectIndex,
+      canEdit: selectIndex === 0})
     this.onFieldMappingChange(
       csvField,
       pdfField,
-      source)
+      (selectIndex === 0) ? TEXT : TABLE)
   }
 
   submitCustomValue(pdfField, source, index) {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -98,8 +98,6 @@ export default class App extends React.Component {
   }
 
   onFieldMappingChange(index, selectIndex) {
-    index = index
-    selectIndex = selectIndex
     let csvFieldValue
     if (selectIndex === 0) {
       csvFieldValue = this.state.availableFieldsState[index].fieldValue

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -36,7 +36,7 @@ export default class App extends React.Component {
     ipcRenderer.on('pdf-fields-available', (event, pdfTemplatePath, fields) => {
       this.setState(prevState => ({
         pdfFields: fields,
-        pdfTemplatePath,
+        pdfTemplatePath: pdfTemplatePath,
         fieldMappings: [],
         availableFieldsState: prevState.pdfFields.map(mapPdfFields)
       }))
@@ -55,7 +55,7 @@ export default class App extends React.Component {
     })
   }
 
-  onLoadPDFFile(){
+  onLoadPDFFile() {
     const filenames = dialog.showOpenDialog({
       properties: ['openFile'],
       filters: [
@@ -121,7 +121,7 @@ export default class App extends React.Component {
             }
         const fieldMappings = [...prevState.fieldMappings]
         fieldMappings[index] = newFieldMappingsEntry
-        return {fieldMappings}
+        return {fieldMappings: fieldMappings}
       })
   }
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -29,7 +29,7 @@ export default class App extends React.Component {
       canEdit: true,
       isEditingCustomValue: false,
       fieldValue: element.fieldValue,
-      selectIndex: 0
+      selectedIndex: 0
     })
 
     ipcRenderer.on('pdf-fields-available', (event, pdfTemplatePath, fields) => {
@@ -106,7 +106,7 @@ export default class App extends React.Component {
               ? Object.assign({}, element, flags.state)
               : element
         )
-        if (flags.shouldSetFieldMappings) {
+        if (flags.shouldSetFieldMapping) {
           const csvFieldValue = (flags.selectedIndex === 0)
             ? prevState.availableFieldsState[index].fieldValue
             : flags.selectedIndex

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -15,8 +15,7 @@ export default class App extends React.Component {
     super(props);
     this.onLoadCSVFile = this.onLoadCSVFile.bind(this)
     this.onLoadPDFFile = this.onLoadPDFFile.bind(this)
-    this.onFieldMappingChange = this.onFieldMappingChange.bind(this)
-    this.setAvailableFieldsState = this.setAvailableFieldsState.bind(this)
+    this.setFieldMapping = this.setFieldMapping.bind(this)
     this.state = {
       pdfFields: [],
       csvFields: [],
@@ -97,46 +96,39 @@ export default class App extends React.Component {
         this.state.fieldMappings.filter(element => typeof element !== 'undefined'))
   }
 
-  onFieldMappingChange(index, selectIndex) {
-    const csvFieldValue = (selectIndex === 0)
-      ? this.state.availableFieldsState[index].fieldValue
-      : selectIndex
-    const mappingSource = (selectIndex === 0) ? TEXT : TABLE
-    const pdfFieldName = this.state.pdfFields[index].fieldName
+  setFieldMapping(index, flags) {
     this.setState(
       prevState => {
-        const newFieldMappingsEntry = (csvFieldValue === "")
-          ? undefined
-          : {
-              fieldName: pdfFieldName,
-              mapping: mappingSource === TABLE
-                ? {
-                    source: TABLE,
-                    columnNumber: csvFieldValue,
-                  }
-                : {
-                    source: TEXT,
-                    text: csvFieldValue,
-                  }
-            }
-        const fieldMappings = [...prevState.fieldMappings]
-        fieldMappings[index] = newFieldMappingsEntry
-        return {fieldMappings: fieldMappings}
-      })
-  }
-
-  setAvailableFieldsState(index, setting) {
-    this.setState(
-      prevState =>
-        ({
-          availableFieldsState: prevState.availableFieldsState.map(
-            (element, i) =>
-              (i === index)
-                ? Object.assign({}, element, setting)
-                : element
-          )
-        })
-    )
+        let partialState = {}
+        partialState.availableFieldsState = prevState.availableFieldsState.map(
+          (element, i) =>
+            (i === index)
+              ? Object.assign({}, element, flags.state)
+              : element
+        )
+        if (flags.shouldSetFieldMappings) {
+          const csvFieldValue = (flags.selectedIndex === 0)
+            ? prevState.availableFieldsState[index].fieldValue
+            : flags.selectedIndex
+          partialState.fieldMappings = [...prevState.fieldMappings]
+          partialState.fieldMappings[index] = (csvFieldValue === "")
+            ? undefined
+            : {
+                fieldName: prevState.pdfFields[index].fieldName,
+                mapping: flags.selectedIndex === 0
+                  ? {
+                      source: TEXT,
+                      text: csvFieldValue,
+                    }
+                  : {
+                      source: TABLE,
+                      columnNumber: csvFieldValue,
+                    }
+              }
+        }
+        return partialState
+      }
+    , console.log(this.state))
   }
 
   render() {
@@ -166,11 +158,10 @@ export default class App extends React.Component {
         <VLAvailableFields
           csvFields={this.state.csvFields}
           pdfFields={this.state.pdfFields}
-          onFieldMappingChange={this.onFieldMappingChange}
           width={WIDTH_OF_COLUMN}
           text={TEXT}
+          setFieldMapping={this.setFieldMapping}
           availableFieldsState={this.state.availableFieldsState}
-          setAvailableFieldsState={this.setAvailableFieldsState}
         />
 
         <div>

--- a/src/components/VLAvailableFields.jsx
+++ b/src/components/VLAvailableFields.jsx
@@ -26,7 +26,6 @@ const VLAvailableFields = (props) => {
           props.pdfFields.map((pdfElement, index) =>
             <VLFieldMappingInput
               key={`${pdfElement.fieldName}Div2`}
-              table={props.table}
               text={props.text}
               empty={props.empty}
               width={props.width}

--- a/src/components/VLAvailableFields.jsx
+++ b/src/components/VLAvailableFields.jsx
@@ -32,8 +32,8 @@ const VLAvailableFields = (props) => {
               csvFields={props.csvFields}
               pdfFields={props.pdfFields}
               pdfElement={pdfElement}
-              settings={props.availableFieldsSettings[index]}
-              mapInput={props.mapInput}
+              state={props.availableFieldsState[index]}
+              updateFieldMappings={props.updateFieldMappings}
               updateFieldValue={props.updateFieldValue}
               editCustomValue={props.editCustomValue}
               submitCustomValue={props.submitCustomValue}

--- a/src/components/VLAvailableFields.jsx
+++ b/src/components/VLAvailableFields.jsx
@@ -31,8 +31,7 @@ const VLAvailableFields = (props) => {
               csvFields={props.csvFields}
               state={props.availableFieldsState[index]}
               index={index}
-              setAvailableFieldsState={props.setAvailableFieldsState}
-              onFieldMappingChange={props.onFieldMappingChange}/>)}
+              setFieldMapping={props.setFieldMapping}/>)}
       </div>
       <div style={{fontSize: '10em',
         display: props.csvFields.length === 0 ? 'initial' : 'none'}}>2</div>

--- a/src/components/VLAvailableFields.jsx
+++ b/src/components/VLAvailableFields.jsx
@@ -23,7 +23,7 @@ const VLAvailableFields = (props) => {
         display: props.pdfFields.length === 0 ? 'initial' : 'none'}}>1</div>
       <div style={{display: props.csvFields.length === 0 ? 'none' : 'grid'}}>
         {props.csvFields.length === 0 ? [] :
-          props.pdfFields.map(pdfElement =>
+          props.pdfFields.map((pdfElement, index) =>
             <VLFieldMappingInput
               key={`${pdfElement.fieldName}Div2`}
               table={props.table}
@@ -33,6 +33,12 @@ const VLAvailableFields = (props) => {
               csvFields={props.csvFields}
               pdfFields={props.pdfFields}
               pdfElement={pdfElement}
+              settings={props.availableFieldsSettings[index]}
+              mapInput={props.mapInput}
+              updateFieldValue={props.updateFieldValue}
+              editCustomValue={props.editCustomValue}
+              submitCustomValue={props.submitCustomValue}
+              index={index}
               onFieldMappingChange={props.onFieldMappingChange}/>)}
       </div>
       <div style={{fontSize: '10em',

--- a/src/components/VLAvailableFields.jsx
+++ b/src/components/VLAvailableFields.jsx
@@ -27,17 +27,11 @@ const VLAvailableFields = (props) => {
             <VLFieldMappingInput
               key={`${pdfElement.fieldName}Div2`}
               text={props.text}
-              empty={props.empty}
               width={props.width}
               csvFields={props.csvFields}
-              pdfFields={props.pdfFields}
-              pdfElement={pdfElement}
               state={props.availableFieldsState[index]}
-              updateFieldMappings={props.updateFieldMappings}
-              updateFieldValue={props.updateFieldValue}
-              editCustomValue={props.editCustomValue}
-              submitCustomValue={props.submitCustomValue}
               index={index}
+              setAvailableFieldsState={props.setAvailableFieldsState}
               onFieldMappingChange={props.onFieldMappingChange}/>)}
       </div>
       <div style={{fontSize: '10em',

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -10,7 +10,6 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMapping: true,
         selectedIndex: selectedIndex,
         state: {
                  selectedIndex: selectedIndex,
@@ -24,7 +23,6 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMapping: true,
         selectedIndex: 0,
         state: {
                  isEditingCustomValue: false
@@ -41,7 +39,6 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMapping: false,
         state: {
                  fieldValue: event.target.value
                }
@@ -53,7 +50,6 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMapping: false,
         state: {
                  isEditingCustomValue: true
                }

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -11,10 +11,8 @@ const VLFieldMappingInput = (props) => {
         onChange={event => {props.mapInput(
           props.pdfElement.fieldName,
           event.target.value,
-          (event.target.options.selectedIndex === 0) ?
-            props.text : props.table,
-          event.target.options.selectedIndex === 0,
-          props.index)
+          props.index,
+          event.target.options.selectedIndex)
         }}
         value={props.settings.selectIndex}
         style={{maxWidth: '13em',

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -5,23 +5,46 @@ const VLFieldMappingInput = (props) => {
     <option value={csvElement.columnNumber}
       key={`${csvElement.columnNumber}-col`}>{csvElement.fieldName}</option>)
 
-  const selectHandler = event => props.updateFieldMappings(
-    props.pdfElement.fieldName,
-    event.target.value,
-    props.index,
-    event.target.options.selectedIndex)
+  const selectHandler = event => {
+    const selectIndex = event.target.options.selectedIndex
+    props.setAvailableFieldsState(
+      props.index,
+      {
+        selectIndex,
+        canEdit: selectIndex === 0
+      }
+    )
+    props.onFieldMappingChange(
+      props.index,
+      selectIndex
+    )
+  }
 
+  const submitCustomValue = () => {
+    props.setAvailableFieldsState(
+      props.index,
+      {
+        isEditingCustomValue: false
+      }
+    )
+    props.onFieldMappingChange(
+      props.index,
+      0
+    )
+  }
 
-  const inputHandler = event => props.updateFieldValue(
-    event,
-    props.pdfElement.fieldName,
-    props.text,
-    props.index)
-
-  const okButtonHandler = () => props.submitCustomValue(
-    props.pdfElement,
-    props.text,
-    props.index)
+  const inputHandler = event => {
+    if(event.key == 'Enter') {
+      submitCustomValue()
+      return
+    }
+    props.setAvailableFieldsState(
+      props.index,
+      {
+        fieldValue: event.target.value
+      }
+    )
+  }
 
   return (
     <div>
@@ -32,7 +55,7 @@ const VLFieldMappingInput = (props) => {
         height: '1.5em',
         display: props.state.isEditingCustomValue ? 'none' : 'initial'}}>
         <option value={props.state.fieldValue}>{props.state.fieldValue === ''
-          ? props.empty : `Text: "${props.state.fieldValue}"`}</option>
+          ? "<empty>" : `Text: "${props.state.fieldValue}"`}</option>
         {options}
       </select>
       <input type="text" style={{width: '12.75em',
@@ -45,11 +68,11 @@ const VLFieldMappingInput = (props) => {
         display: props.state.isEditingCustomValue ? 'none' : 'initial',
         height: '1.5em'}}
         disabled={!props.state.canEdit}
-        onClick={() => props.editCustomValue(props.index)}>p</button>
+        onClick={() => props.setAvailableFieldsState(props.index, {isEditingCustomValue: true})}>p</button>
       <button style={{width: '2em',
         height: '1.5em',
         display: props.state.isEditingCustomValue ? 'initial' : 'none'}}
-        onClick={okButtonHandler}>ok</button>
+        onClick={submitCustomValue}>ok</button>
     </div>
   )
 }

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -1,79 +1,56 @@
 import React from 'react'
 
-export default class VLFieldMappingInput extends React.Component {
-  constructor(props) {
-    super(props)
-    this.mapInput = this.mapInput.bind(this)
-    this.editCustomValue = this.editCustomValue.bind(this)
-    this.submitCustomValue = this.submitCustomValue.bind(this)
-    this.updateFieldValue = this.updateFieldValue.bind(this)
-    this.state = {
-      canEdit: true,
-      isEditingCustomValue: false,
-      fieldValue: this.props.pdfElement.fieldValue
-    }
-  }
+const VLFieldMappingInput = (props) => {
+  const options = props.csvFields.map(csvElement =>
+    <option value={csvElement.columnNumber}
+      key={`${csvElement.columnNumber}-col`}>{csvElement.fieldName}</option>)
 
-  editCustomValue() {
-    this.setState({isEditingCustomValue: true})
-  }
-
-  submitCustomValue(event) {
-    this.setState({isEditingCustomValue: false})
-    this.props.onFieldMappingChange(
-      this.state.fieldValue,
-      this.props.pdfElement.fieldName,
-      this.props.text)
-  }
-
-  mapInput(event) {
-    this.setState({canEdit: event.target.options.selectedIndex === 0})
-    this.props.onFieldMappingChange(
-      event.target.value,
-      this.props.pdfElement.fieldName,
-      (event.target.options.selectedIndex === 0) ?
-        this.props.text : this.props.table)
-  }
-
-  updateFieldValue(event) {
-    if(event.key == 'Enter') {
-      this.submitCustomValue(event)
-      return
-    }
-    this.setState({fieldValue: event.target.value})
-  }
-
-  render() {
-    const options = this.props.csvFields.map(csvElement =>
-      <option value={csvElement.columnNumber}
-        key={`${csvElement.columnNumber}-col`}>{csvElement.fieldName}</option>)
-
-    return (
-      <div>
-        <select
-          onChange={this.mapInput}
-          style={{maxWidth: '13em',
-          height: '1.5em',
-          display: this.state.isEditingCustomValue ? 'none' : 'initial'}}>
-          <option value={this.state.fieldValue}>{this.state.fieldValue === ''
-            ? this.props.empty : `Text: "${this.state.fieldValue}"`}</option>
-          {options}
-        </select>
-        <input type="text" style={{width: '12.75em',
-          height: '1em',
-          display: this.state.isEditingCustomValue ? 'initial' : 'none'}}
-          onChange={this.updateFieldValue}
-          onKeyPress={this.updateFieldValue}></input>
-        <button style={{width: '2em',
-          display: this.state.isEditingCustomValue ? 'none' : 'initial',
-          height: '1.5em'}}
-          disabled={!this.state.canEdit}
-          onClick={this.editCustomValue}>p</button>
-        <button style={{width: '2em',
-          height: '1.5em',
-          display: this.state.isEditingCustomValue ? 'initial' : 'none'}}
-          onClick={this.submitCustomValue}>ok</button>
-      </div>
-    )
-  }
+  return (
+    <div>
+      <select
+        onChange={event => {props.mapInput(
+          props.pdfElement.fieldName,
+          event.target.value,
+          (event.target.options.selectedIndex === 0) ?
+            props.text : props.table,
+          event.target.options.selectedIndex === 0,
+          props.index)
+        }}
+        style={{maxWidth: '13em',
+        height: '1.5em',
+        display: props.settings.isEditingCustomValue ? 'none' : 'initial'}}>
+        <option value={props.settings.fieldValue}>{props.settings.fieldValue === ''
+          ? props.empty : `Text: "${props.settings.fieldValue}"`}</option>
+        {options}
+      </select>
+      <input type="text" style={{width: '12.75em',
+        height: '1em',
+        display: props.settings.isEditingCustomValue ? 'initial' : 'none'}}
+        onChange={event => props.updateFieldValue(
+          event,
+          props.pdfElement.fieldName,
+          props.text,
+          props.index)}
+        onKeyPress={event => props.updateFieldValue(
+          event,
+          props.pdfElement.fieldName,
+          props.text,
+          props.index)}></input>
+      <button style={{width: '2em',
+        display: props.settings.isEditingCustomValue ? 'none' : 'initial',
+        height: '1.5em'}}
+        disabled={!props.settings.canEdit}
+        onClick={() => props.editCustomValue(props.index)}>p</button>
+      <button style={{width: '2em',
+        height: '1.5em',
+        display: props.settings.isEditingCustomValue ? 'initial' : 'none'}}
+        onClick={(event) => props.submitCustomValue(
+          props.pdfElement,
+          props.text,
+          props.index
+        )}>ok</button>
+    </div>
+  )
 }
+
+export default VLFieldMappingInput

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -6,30 +6,30 @@ const VLFieldMappingInput = (props) => {
       key={`${csvElement.columnNumber}-col`}>{csvElement.fieldName}</option>)
 
   const selectHandler = event => {
-    const selectIndex = event.target.options.selectedIndex
-    props.setAvailableFieldsState(
+    const selectedIndex = event.target.options.selectedIndex
+    props.setFieldMapping(
       props.index,
       {
-        selectIndex: selectIndex,
-        canEdit: selectIndex === 0
+        shouldSetFieldMappings: true,
+        selectedIndex: selectedIndex,
+        state: {
+                 selectIndex: selectedIndex,
+                 canEdit: selectedIndex === 0
+               }
       }
-    )
-    props.onFieldMappingChange(
-      props.index,
-      selectIndex
     )
   }
 
   const submitCustomValue = () => {
-    props.setAvailableFieldsState(
+    props.setFieldMapping(
       props.index,
       {
-        isEditingCustomValue: false
+        shouldSetFieldMappings: true,
+        selectedIndex: 0,
+        state: {
+                 isEditingCustomValue: false
+               }
       }
-    )
-    props.onFieldMappingChange(
-      props.index,
-      0
     )
   }
 
@@ -38,13 +38,27 @@ const VLFieldMappingInput = (props) => {
       submitCustomValue()
       return
     }
-    props.setAvailableFieldsState(
+    props.setFieldMapping(
       props.index,
       {
-        fieldValue: event.target.value
+        shouldSetFieldMappings: false,
+        state: {
+                 fieldValue: event.target.value
+               }
       }
     )
   }
+
+  const changeToEdit = () =>
+    props.setFieldMapping(
+      props.index,
+      {
+        shouldSetFieldMappings: false,
+        state: {
+                 isEditingCustomValue: true
+               }
+      }
+    )
 
   return (
     <div>
@@ -68,7 +82,7 @@ const VLFieldMappingInput = (props) => {
         display: props.state.isEditingCustomValue ? 'none' : 'initial',
         height: '1.5em'}}
         disabled={!props.state.canEdit}
-        onClick={() => props.setAvailableFieldsState(props.index, {isEditingCustomValue: true})}>p</button>
+        onClick={changeToEdit}>p</button>
       <button style={{width: '2em',
         height: '1.5em',
         display: props.state.isEditingCustomValue ? 'initial' : 'none'}}

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -16,6 +16,7 @@ const VLFieldMappingInput = (props) => {
           event.target.options.selectedIndex === 0,
           props.index)
         }}
+        value={props.settings.selectIndex}
         style={{maxWidth: '13em',
         height: '1.5em',
         display: props.settings.isEditingCustomValue ? 'none' : 'initial'}}>
@@ -26,6 +27,7 @@ const VLFieldMappingInput = (props) => {
       <input type="text" style={{width: '12.75em',
         height: '1em',
         display: props.settings.isEditingCustomValue ? 'initial' : 'none'}}
+        value={props.settings.fieldValue}
         onChange={event => props.updateFieldValue(
           event,
           props.pdfElement.fieldName,

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -10,10 +10,10 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMappings: true,
+        shouldSetFieldMapping: true,
         selectedIndex: selectedIndex,
         state: {
-                 selectIndex: selectedIndex,
+                 selectedIndex: selectedIndex,
                  canEdit: selectedIndex === 0
                }
       }
@@ -24,7 +24,7 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMappings: true,
+        shouldSetFieldMapping: true,
         selectedIndex: 0,
         state: {
                  isEditingCustomValue: false
@@ -41,7 +41,7 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMappings: false,
+        shouldSetFieldMapping: false,
         state: {
                  fieldValue: event.target.value
                }
@@ -53,7 +53,7 @@ const VLFieldMappingInput = (props) => {
     props.setFieldMapping(
       props.index,
       {
-        shouldSetFieldMappings: false,
+        shouldSetFieldMapping: false,
         state: {
                  isEditingCustomValue: true
                }
@@ -64,7 +64,7 @@ const VLFieldMappingInput = (props) => {
     <div>
       <select
         onChange={selectHandler}
-        value={props.state.selectIndex}
+        value={props.state.selectedIndex}
         style={{maxWidth: '13em',
         height: '1.5em',
         display: props.state.isEditingCustomValue ? 'none' : 'initial'}}>

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -5,12 +5,12 @@ const VLFieldMappingInput = (props) => {
     <option value={csvElement.columnNumber}
       key={`${csvElement.columnNumber}-col`}>{csvElement.fieldName}</option>)
 
-  const selectHandler = event => {props.mapInput(
+  const selectHandler = event => props.updateFieldMappings(
     props.pdfElement.fieldName,
     event.target.value,
     props.index,
     event.target.options.selectedIndex)
-  }
+
 
   const inputHandler = event => props.updateFieldValue(
     event,
@@ -21,35 +21,34 @@ const VLFieldMappingInput = (props) => {
   const okButtonHandler = () => props.submitCustomValue(
     props.pdfElement,
     props.text,
-    props.index
-  )
+    props.index)
 
   return (
     <div>
       <select
         onChange={selectHandler}
-        value={props.settings.selectIndex}
+        value={props.state.selectIndex}
         style={{maxWidth: '13em',
         height: '1.5em',
-        display: props.settings.isEditingCustomValue ? 'none' : 'initial'}}>
-        <option value={props.settings.fieldValue}>{props.settings.fieldValue === ''
-          ? props.empty : `Text: "${props.settings.fieldValue}"`}</option>
+        display: props.state.isEditingCustomValue ? 'none' : 'initial'}}>
+        <option value={props.state.fieldValue}>{props.state.fieldValue === ''
+          ? props.empty : `Text: "${props.state.fieldValue}"`}</option>
         {options}
       </select>
       <input type="text" style={{width: '12.75em',
         height: '1em',
-        display: props.settings.isEditingCustomValue ? 'initial' : 'none'}}
-        value={props.settings.fieldValue}
+        display: props.state.isEditingCustomValue ? 'initial' : 'none'}}
+        value={props.state.fieldValue}
         onChange={inputHandler}
         onKeyPress={inputHandler}></input>
       <button style={{width: '2em',
-        display: props.settings.isEditingCustomValue ? 'none' : 'initial',
+        display: props.state.isEditingCustomValue ? 'none' : 'initial',
         height: '1.5em'}}
-        disabled={!props.settings.canEdit}
+        disabled={!props.state.canEdit}
         onClick={() => props.editCustomValue(props.index)}>p</button>
       <button style={{width: '2em',
         height: '1.5em',
-        display: props.settings.isEditingCustomValue ? 'initial' : 'none'}}
+        display: props.state.isEditingCustomValue ? 'initial' : 'none'}}
         onClick={okButtonHandler}>ok</button>
     </div>
   )

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -10,7 +10,7 @@ const VLFieldMappingInput = (props) => {
     props.setAvailableFieldsState(
       props.index,
       {
-        selectIndex,
+        selectIndex: selectIndex,
         canEdit: selectIndex === 0
       }
     )

--- a/src/components/VLFieldMappingInput.jsx
+++ b/src/components/VLFieldMappingInput.jsx
@@ -5,15 +5,29 @@ const VLFieldMappingInput = (props) => {
     <option value={csvElement.columnNumber}
       key={`${csvElement.columnNumber}-col`}>{csvElement.fieldName}</option>)
 
+  const selectHandler = event => {props.mapInput(
+    props.pdfElement.fieldName,
+    event.target.value,
+    props.index,
+    event.target.options.selectedIndex)
+  }
+
+  const inputHandler = event => props.updateFieldValue(
+    event,
+    props.pdfElement.fieldName,
+    props.text,
+    props.index)
+
+  const okButtonHandler = () => props.submitCustomValue(
+    props.pdfElement,
+    props.text,
+    props.index
+  )
+
   return (
     <div>
       <select
-        onChange={event => {props.mapInput(
-          props.pdfElement.fieldName,
-          event.target.value,
-          props.index,
-          event.target.options.selectedIndex)
-        }}
+        onChange={selectHandler}
         value={props.settings.selectIndex}
         style={{maxWidth: '13em',
         height: '1.5em',
@@ -26,16 +40,8 @@ const VLFieldMappingInput = (props) => {
         height: '1em',
         display: props.settings.isEditingCustomValue ? 'initial' : 'none'}}
         value={props.settings.fieldValue}
-        onChange={event => props.updateFieldValue(
-          event,
-          props.pdfElement.fieldName,
-          props.text,
-          props.index)}
-        onKeyPress={event => props.updateFieldValue(
-          event,
-          props.pdfElement.fieldName,
-          props.text,
-          props.index)}></input>
+        onChange={inputHandler}
+        onKeyPress={inputHandler}></input>
       <button style={{width: '2em',
         display: props.settings.isEditingCustomValue ? 'none' : 'initial',
         height: '1.5em'}}
@@ -44,11 +50,7 @@ const VLFieldMappingInput = (props) => {
       <button style={{width: '2em',
         height: '1.5em',
         display: props.settings.isEditingCustomValue ? 'initial' : 'none'}}
-        onClick={(event) => props.submitCustomValue(
-          props.pdfElement,
-          props.text,
-          props.index
-        )}>ok</button>
+        onClick={okButtonHandler}>ok</button>
     </div>
   )
 }


### PR DESCRIPTION
VLFieldMappingInput previously had self-contained state, but the
information flowed against the current of the rest of the app and
the increase in listeners was negatively affecting performance.

Lifting state centralizes information and handlers. VLFieldMappingInput
has been converted to a functional component, which reflects
its presentational-only nature. Further refactoring may be needed
to help unpacking parameters and calls to setState.