### PR TITLE
Corrected application logic

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -25,7 +25,7 @@ export default class App extends React.Component {
       availableFieldsState: [],
     }
 
-    const mapPdfFields = element => ({
+    const mapPdfFieldsToAvailableFields = element => ({
       canEdit: true,
       isEditingCustomValue: false,
       fieldValue: element.fieldValue,
@@ -37,7 +37,7 @@ export default class App extends React.Component {
         pdfFields: fields,
         pdfTemplatePath: pdfTemplatePath,
         fieldMappings: [],
-        availableFieldsState: prevState.pdfFields.map(mapPdfFields)
+        availableFieldsState: fields.map(mapPdfFieldsToAvailableFields)
       }))
     })
 
@@ -45,7 +45,7 @@ export default class App extends React.Component {
       this.setState(prevState => ({
         csvFields: fields,
         fieldMappings: [],
-        availableFieldsState: prevState.pdfFields.map(mapPdfFields)
+        availableFieldsState: prevState.pdfFields.map(mapPdfFieldsToAvailableFields)
       }))
     })
 

--- a/src/components/VLAvailableFields.jsx
+++ b/src/components/VLAvailableFields.jsx
@@ -22,16 +22,17 @@ const VLAvailableFields = (props) => {
       <div style={{fontSize: '10em',
         display: props.pdfFields.length === 0 ? 'initial' : 'none'}}>1</div>
       <div style={{display: props.csvFields.length === 0 ? 'none' : 'grid'}}>
-        {props.csvFields.length === 0 ? [] :
-          props.pdfFields.map((pdfElement, index) =>
-            <VLFieldMappingInput
-              key={`${pdfElement.fieldName}Div2`}
-              text={props.text}
-              width={props.width}
-              csvFields={props.csvFields}
-              state={props.availableFieldsState[index]}
-              index={index}
-              setFieldMapping={props.setFieldMapping}/>)}
+        {props.pdfFields.map((pdfElement, index) =>
+          <VLFieldMappingInput
+            style={{display: props.csvFields.length === 0 ? 'none' : 'initial'}}
+            key={`${pdfElement.fieldName}Div2`}
+            text={props.text}
+            width={props.width}
+            csvFields={props.csvFields}
+            state={props.availableFieldsState[index]}
+            index={index}
+            setFieldMapping={props.setFieldMapping}/>)
+        }
       </div>
       <div style={{fontSize: '10em',
         display: props.csvFields.length === 0 ? 'initial' : 'none'}}>2</div>


### PR DESCRIPTION
Previously, the code mapped availableFieldsState from an
older version of pdfFields every time a new set of
pdfFields became available. Now, availableFieldsState
is current to the information immediately after a
PDF is loaded. In addition, I've removed the
conditional mounting of <VLFieldMappingInput>
as it already responds correctly to the changes in
pdfFields and csvFields. In place, I've made the CSS
display attribute responsive.