### PR TITLE
Fix Promise.all() call for PDF generation results.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -253,7 +253,7 @@ ipcMain.on('generate-pdfs', (event, pdfTemplatePath, pdfOutputPathTemplate, fiel
         }));
   });
 
-  Promise.all(pdftkPromises, () => {
+  Promise.all(pdftkPromises).then(() => {
     event.sender.send('pdf-generation-finished', generatedPdfs, errors);
   });
 });


### PR DESCRIPTION
I thought I had previously fixed this in commit ed07b75,
but Promise.all() doesn't work with callback syntax.
Given that there are no tests for PDF generation results and
the UI hasn't hooked it up either, my error went unnoticed.

It's still untested, but this change mirrors the learnings
from another, tested, change. It's more likely to work now.